### PR TITLE
Fixing typo with low pass filter

### DIFF
--- a/ros/src/twist_controller/steer_controller.py
+++ b/ros/src/twist_controller/steer_controller.py
@@ -34,7 +34,7 @@ class Steer_Controller(object):
         steer = self.yaw_controller.get_steering(linear_velocity,
                                                  angular_velocity,
                                                  current_velocity)
-        steer = self.lp_fiter(steer)
+        steer = self.lp_fiter.filt(steer)
         return steer
 
     # Method to limit a value between min and max arguments


### PR DESCRIPTION
I forgot to add the call to the member function.